### PR TITLE
0 char bug fix, execute/cancel toggle bug fix, new error popup for 0 files found

### DIFF
--- a/NMSVRScreenshotFix.java
+++ b/NMSVRScreenshotFix.java
@@ -109,7 +109,8 @@ class LogicController {
         File[] folderContents = sourceFolder.listFiles();
         totalFiles = folderContents.length;
         File curFile;
-
+        
+        myUI.toggleUI();
         
         for (int fileIndex = 0; fileIndex < totalFiles && !canceled; fileIndex++) {
             curFile = folderContents[fileIndex];
@@ -134,6 +135,7 @@ class LogicController {
         
         isExecuting = false;
         System.out.println("finished");
+        myUI.toggleUI();
     }
     
      /**
@@ -269,6 +271,10 @@ class LogicController {
     }
     
     public boolean isValidAddition(String phrase) {
+        
+        if(phrase.length() == 0) {
+            return false;
+        }
         
         for (int charIndex = 0; charIndex < phrase.length(); charIndex++) {
             char curChar = phrase.charAt(charIndex);

--- a/ProgramUI.form
+++ b/ProgramUI.form
@@ -88,12 +88,14 @@
                       </Group>
                   </Group>
                   <EmptySpace min="-2" pref="17" max="-2" attributes="0"/>
-                  <Group type="103" groupAlignment="3" attributes="0">
-                      <Component id="resultFolderButton" alignment="3" min="-2" max="-2" attributes="0"/>
-                      <Component id="jLabel3" max="32767" attributes="0"/>
+                  <Group type="103" groupAlignment="0" attributes="0">
                       <Group type="102" alignment="1" attributes="0">
                           <EmptySpace min="1" pref="1" max="-2" attributes="0"/>
                           <Component id="resultFolderField" pref="32" max="32767" attributes="0"/>
+                      </Group>
+                      <Group type="103" groupAlignment="3" attributes="0">
+                          <Component id="resultFolderButton" alignment="3" min="-2" max="-2" attributes="0"/>
+                          <Component id="jLabel3" max="32767" attributes="0"/>
                       </Group>
                   </Group>
                   <EmptySpace type="unrelated" min="-2" max="-2" attributes="0"/>

--- a/ProgramUI.java
+++ b/ProgramUI.java
@@ -150,12 +150,13 @@ public class ProgramUI extends javax.swing.JFrame {
                         .addGap(23, 23, 23)
                         .addComponent(jLabel2, javax.swing.GroupLayout.PREFERRED_SIZE, 32, javax.swing.GroupLayout.PREFERRED_SIZE)))
                 .addGap(17, 17, 17)
-                .addGroup(jPanel3Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(resultFolderButton, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel3, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addGroup(jPanel3Layout.createSequentialGroup()
+                .addGroup(jPanel3Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel3Layout.createSequentialGroup()
                         .addGap(1, 1, 1)
-                        .addComponent(resultFolderField, javax.swing.GroupLayout.DEFAULT_SIZE, 32, Short.MAX_VALUE)))
+                        .addComponent(resultFolderField, javax.swing.GroupLayout.DEFAULT_SIZE, 32, Short.MAX_VALUE))
+                    .addGroup(jPanel3Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                        .addComponent(resultFolderButton, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addComponent(jLabel3, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addGroup(jPanel3Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(jLabel1, javax.swing.GroupLayout.PREFERRED_SIZE, 25, javax.swing.GroupLayout.PREFERRED_SIZE)
@@ -186,14 +187,13 @@ public class ProgramUI extends javax.swing.JFrame {
     private void executeButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_executeButtonActionPerformed
         if(controller.isExecuting) {
             controller.cancelExecution();
-            toggleUI();
+
         }
         else {
             controller.sourcePath = sourceFolderField.getText();
             controller.resultPath = resultFolderField.getText();
             if (controller.hasValidDirectoryPaths()) {
                 controller.execute();
-                toggleUI();
             }
             else {
                 JOptionPane.showMessageDialog(this,
@@ -242,7 +242,7 @@ public class ProgramUI extends javax.swing.JFrame {
         behaviorTextArea.setText(controller.getCurrentBehavior());
     }//GEN-LAST:event_sourceFolderFieldActionPerformed
 
-    private void toggleUI() {
+    public void toggleUI() {
         boolean shouldEnable = !controller.isExecuting;
         settingsButton.setEnabled(shouldEnable);
         sourceFolderField.setEnabled(shouldEnable);
@@ -259,10 +259,17 @@ public class ProgramUI extends javax.swing.JFrame {
     }
     
     public void successPopup(int value) {
-        JOptionPane.showMessageDialog(this,
-            ("Converted " + value + " images successfully."),"Complete",
+        if(value != 0) {
+            JOptionPane.showMessageDialog(this,
+            ("All " + value + " images were converted successfully."),"Complete",
             JOptionPane.INFORMATION_MESSAGE);
-        progressBar.setValue(0);
+            progressBar.setValue(0);
+        } else {
+            JOptionPane.showMessageDialog(this,
+            ("No images were found in the source folder."),"Error: No images found",
+            JOptionPane.WARNING_MESSAGE);
+            progressBar.setValue(0);
+        }
     }
     
     public void cancelPopup(int value) {

--- a/SettingsUI.java
+++ b/SettingsUI.java
@@ -254,7 +254,7 @@ public class SettingsUI extends javax.swing.JDialog {
         }
         else {
             JOptionPane.showMessageDialog(this,
-                    "Text can only contain alphanumeric characters, '_' and '-'.","Error",
+                    "Text must contain only alphanumeric characters, '_', and '-'.","Error",
                     JOptionPane.WARNING_MESSAGE);
         }
     }//GEN-LAST:event_ConfirmButtonActionPerformed


### PR DESCRIPTION
added a check for zero character prefix/suffix text. modified text error accordingly.
added a new popup to the successful conversion method to account for the case of finding zero images.
fixed a bug with the Execute/Cancel button not toggling at the appropriate time

fixes #1 